### PR TITLE
Support multiple API tokens

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,11 @@
-H1_API_USERNAME=fill this in!
-H1_API_PASSWORD=fill this in!
+# You can define any number of HackerOne programs to track.
+H1_PROGRAM_1=my-first-program:my-first-api-username:my-first-api-password
+
+# If you don't want to track a second program, delete the following line.
+H1_PROGRAM_2=my-second-program:my-second-api-username:my-second-api-password
+
+# If you want to track a third program, just define H1_PROGRAM_3, and so on...
+
 DEBUG=yup
 
 # This only matters if developing using Docker.

--- a/README.md
+++ b/README.md
@@ -123,14 +123,18 @@ string), the boolean is true; otherwise, it's false.
   [`DEFAULT_FROM_EMAIL`][] setting. It defaults to `noreply@localhost`
   when `DEBUG=True`.
 
-* `H1_API_USERNAME` is your HackerOne API Token identifier. For more
-  details, see the [HackerOne API Authentication docs][h1docs].
+* `H1_PROGRAM_n`, where `n` is an integer starting at 1, describes the
+  configuration of the `n`th HackerOne program that you'd like the
+  dashboard to track. Each configuration consists of the program
+  handle, the API token identifier (aka API username), and API token
+  value (aka API password), all delimited by colons.
 
-* `H1_API_PASSWORD` is your HackerOne API Token value. For more
-  details, see the [HackerOne API Authentication docs][h1docs].
+  Thus for instance if you wanted to track two programs, `tts` and
+  `tts-private`, each with their own separate API credentials, you might
+  define `H1_PROGRAM_1=tts:foo:bar` and `H1_PROGRAM_2=tts-private:baz:quux`.
 
-* `H1_PROGRAMS` is a comma-separated list, without any whitespace, of
-  the HackerOne program handles you want to generate statistics on.
+  For more details on the configuration parameters, see the
+  [HackerOne API Authentication docs][h1docs].
 
 * `UAA_CLIENT_ID` is your cloud.gov/Cloud Foundry UAA client ID. It
   defaults to `bugbounty-dev`.

--- a/bugbounty/settings.py
+++ b/bugbounty/settings.py
@@ -16,6 +16,9 @@ from dotenv import load_dotenv
 import dj_database_url
 import dj_email_url
 
+from dashboard.h1 import ProgramConfiguration
+
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -24,9 +27,10 @@ dotenv_path = os.path.join(BASE_DIR, '.env')
 if os.path.exists(dotenv_path):
     load_dotenv(dotenv_path)
 
-H1_API_USERNAME = os.environ['H1_API_USERNAME']
-H1_API_PASSWORD = os.environ['H1_API_PASSWORD']
-H1_PROGRAMS = os.environ.get('H1_PROGRAMS', 'tts').split(',')
+H1_PROGRAMS = ProgramConfiguration.parse_list_from_environ(
+    prefix='H1_PROGRAM_',
+    environ=os.environ,
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/

--- a/dashboard/management/commands/h1sync.py
+++ b/dashboard/management/commands/h1sync.py
@@ -27,10 +27,9 @@ class Command(BaseCommand):
             kwargs['last_activity_at__gt'] = metadata.last_synced_at
 
         listing = h1.find_reports(**kwargs)
-        count = len(listing)
-        records = "records" if count != 1 else "record"
-        self.stdout.write(f"Synchronizing {count} {records} with HackerOne.")
+        count = 0
         for h1_report in listing:
+            self.stdout.write(f"Synchronizing #{h1_report.id}.")
             scope = h1_report.structured_scope
             Report.objects.update_or_create(
                 defaults=dict(
@@ -46,6 +45,10 @@ class Command(BaseCommand):
                 ),
                 id=h1_report.id
             )
+            count += 1
+        records = "records" if count != 1 else "record"
+        self.stdout.write(f"Synchronized {count} {records} with HackerOne.")
+
         metadata.last_synced_at = now
         metadata.save()
         self.stdout.write("Done.")

--- a/dashboard/tests/test_h1.py
+++ b/dashboard/tests/test_h1.py
@@ -4,23 +4,52 @@ from unittest import mock
 from .. import h1
 
 
-@override_settings(H1_API_USERNAME='foo', H1_API_PASSWORD='bar',
-                   H1_PROGRAMS=['baz'])
+@override_settings(H1_PROGRAMS=[
+    h1.ProgramConfiguration(handle='baz',
+                            api_username='foo',
+                            api_password='bar')
+])
 @mock.patch('dashboard.h1.HackerOneClient')
 def test_find_reports_works(fake_client_class):
     fake_client = mock.MagicMock()
     fake_client_class.return_value = fake_client
-    fake_client.find_resources.return_value = "stuff"
+    fake_client.find_resources.return_value = ["stuff"]
 
-    result = h1.find_reports(blah=1)
+    results = [r for r in h1.find_reports(blah=1)]
 
-    assert result == "stuff"
+    assert results == ["stuff"]
     fake_client_class.assert_called_once_with('foo', 'bar')
     fake_client.find_resources.assert_called_once_with(
         h1.h1_models.Report,
         program=['baz'],
         blah=1
     )
+
+
+def test_program_configuration_parse_works():
+    pc = h1.ProgramConfiguration.parse('prog:user:pass:!?:')
+    assert pc.handle == 'prog'
+    assert pc.api_username == 'user'
+    assert pc.api_password == 'pass:!?:'
+
+
+def test_program_configuration_parse_list_from_environ_works():
+    pcs = h1.ProgramConfiguration.parse_list_from_environ(
+        environ={
+            'H1_PROGRAM_1': 'a:b:c',
+            'H1_PROGRAM_2': 'd:e:f',
+        },
+        prefix='H1_PROGRAM_',
+    )
+    assert len(pcs) == 2
+
+    assert pcs[0].handle == 'a'
+    assert pcs[0].api_username == 'b'
+    assert pcs[0].api_password == 'c'
+
+    assert pcs[1].handle == 'd'
+    assert pcs[1].api_username == 'e'
+    assert pcs[1].api_password == 'f'
 
 
 def test_newer_report_works():

--- a/dashboard/tests/test_h1sync.py
+++ b/dashboard/tests/test_h1sync.py
@@ -155,13 +155,13 @@ def test_it_handles_reports_that_are_not_eligible_for_bounty():
 @pytest.mark.django_db
 def test_it_outputs_number_of_records_updated():
     output, _ = call_h1sync(reports=[])
-    assert 'Synchronizing 0 records with HackerOne' in output
+    assert 'Synchronized 0 records with HackerOne' in output
 
     output, _ = call_h1sync(reports=[FakeApiReport()])
-    assert 'Synchronizing 1 record with HackerOne' in output
+    assert 'Synchronized 1 record with HackerOne' in output
 
     output, _ = call_h1sync(reports=[FakeApiReport(), FakeApiReport()])
-    assert 'Synchronizing 2 records with HackerOne' in output
+    assert 'Synchronized 2 records with HackerOne' in output
 
 
 @pytest.mark.django_db

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -2,8 +2,8 @@ version: '2'
 services:
   app:
     environment:
-      - "H1_API_USERNAME=fill this in!"
-      - "H1_API_PASSWORD=fill this in!"
+      - "H1_PROGRAM_1=fill this in!"
+      - "H1_PROGRAM_2=fill this in (or remove it)!"
     volumes:
       # This assumes you're deploying via an Amazon EC2
       # Docker machine. You may need to change the path


### PR DESCRIPTION
This fixes #22.

I was thinking about adding a `ProgramConfiguration` model so the API keys could just be stored in a database, but it'd require rejiggering a bunch of tests and docs so I decided not to. We can still migrate to that setup in the future, though.
