### PR TITLE
Add SingletonMetadata admin

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Report
+from .models import Report, SingletonMetadata
 
 
 @admin.register(Report)
@@ -20,6 +20,17 @@ class ReportAdmin(admin.ModelAdmin):
         'next_nag_at',
     )
     fields = ('is_accurate', 'is_false_negative') + readonly_fields
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+@admin.register(SingletonMetadata)
+class SingletonMetadataAdmin(admin.ModelAdmin):
+    fields = ('last_synced_at',)
 
     def has_add_permission(self, request):
         return False

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -133,6 +133,10 @@ class SingletonMetadata(models.Model):
     A singleton model that stores metadata about the dashboard.
     '''
 
+    class Meta:
+        verbose_name = "dashboard settings"
+        verbose_name_plural = "dashboard settings"
+
     SINGLETON_ID = 1
 
     id = models.PositiveIntegerField(primary_key=True)
@@ -140,7 +144,11 @@ class SingletonMetadata(models.Model):
     last_synced_at = models.DateTimeField(
         blank=True,
         null=True,
-        help_text='When the dashboard was last synced with HackerOne.'
+        help_text=('When the dashboard was last synced with HackerOne. '
+                   'This field generally is not intended for editing, but '
+                   'you can clear it to ensure that the next scheduled '
+                   'sync refreshes all data, which can be useful if the '
+                   'dashboard somehow becomes out-of-sync with HackerOne.')
     )
 
     def save(self, *args, **kwargs):

--- a/dashboard/tests/test_admin.py
+++ b/dashboard/tests/test_admin.py
@@ -1,7 +1,9 @@
 import pytest
 from django.contrib.admin import AdminSite
 
-from ..admin import Report, ReportAdmin
+from ..admin import (
+    Report, ReportAdmin, SingletonMetadata, SingletonMetadataAdmin
+)
 
 
 @pytest.fixture
@@ -10,9 +12,23 @@ def report_admin():
     return ReportAdmin(Report, site)
 
 
+@pytest.fixture
+def singleton_metadata_admin():
+    site = AdminSite()
+    return SingletonMetadataAdmin(SingletonMetadata, site)
+
+
 def test_users_cannot_add_reports(report_admin):
     assert not report_admin.has_add_permission(None)
 
 
 def test_users_cannot_delete_reports(report_admin):
     assert not report_admin.has_delete_permission(None)
+
+
+def test_users_cannot_add_singleton_metadata(singleton_metadata_admin):
+    assert not singleton_metadata_admin.has_add_permission(None)
+
+
+def test_users_cannot_delete_singleton_metadata(singleton_metadata_admin):
+    assert not singleton_metadata_admin.has_delete_permission(None)


### PR DESCRIPTION
Fixes #26.

Calling the model "dashboard settings" in the admin because it makes more sense.